### PR TITLE
Fix java 8 javadoc errors.  Only a partial fix for #34.

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/AlarmManager.java
+++ b/src/main/java/com/vmware/vim25/mo/AlarmManager.java
@@ -135,7 +135,7 @@ public class AlarmManager extends ManagedObject {
      *            The {@link ManagedEntity} to alarm against.
      * @param as
      *            The {@link AlarmSpec} used to generate the alarm.
-     * @return The new {@link ALarm} created
+     * @return The new {@link Alarm} created
      * @throws InvalidName
      *             if the alarm name exceeds the max length or is empty.
      * @throws DuplicateName

--- a/src/main/java/com/vmware/vim25/mo/ManagedObject.java
+++ b/src/main/java/com/vmware/vim25/mo/ManagedObject.java
@@ -161,9 +161,6 @@ abstract public class ManagedObject {
      * @param propertyName The property name of current managed object
      * @return it will return either an array of related data objects, or an data object itself.
      * ManagedObjectReference objects are data objects!!!
-     * @throws RemoteException
-     * @throws RuntimeFault
-     * @throws InvalidProperty
      */
 
     protected Object getCurrentProperty(String propertyName) {


### PR DESCRIPTION
This is only a partial fix for issue #34 as it only fixes the outstanding javadoc errors I saw when using javadoc with java 8.  There are still over 100 javadoc warnings, but 'gradlew javadoc' does complete successfully with this change.